### PR TITLE
RMX1971: Fix status bar height for certain apps on 12L

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -20,7 +20,7 @@
 <resources>
 
     <!-- Height of the status bar in portrait -->
-    <dimen name="status_bar_height_portrait">32.0dip</dimen>
+    <dimen name="status_bar_height">32.0dip</dimen>
 
     <!-- Height of the status bar in landscape -->
     <dimen name="status_bar_height_landscape">24dp</dimen>


### PR DESCRIPTION
* 12L introduced new API to fetch status bar height based on cutout, to
  handle multi-display devices. However, some apps directly read the
  height from overlay so the layout is broken for them.
* Since our device is not a multi-display one, set the expected height
  in overlay directly as the old way to make these apps look good.

Change-Id: I38fae2cdd20b947998766b35920d28bebcf547cf
Signed-off-by: MadhavSaladi <baaswanthmadhav@gmail.com>